### PR TITLE
Support for string interpolation, help comments, and some special variables

### DIFF
--- a/syntax/ps1.vim
+++ b/syntax/ps1.vim
@@ -97,6 +97,13 @@ syn match   ps1Number		"\(\<\d\+\.\d*\|\.\d\+\)\([eE][-+]\=\d\+\)\=[dD]\="
 syn match   ps1Number		"\<\d\+[eE][-+]\=\d\+[dD]\=\>"
 syn match   ps1Number		"\<\d\+\([eE][-+]\=\d\+\)\=[dD]\>"
 
+" Constants
+syn match ps1Boolean "$\%(true\|false\)\>"
+syn match ps1Constant /\$null\>/
+syn match ps1BuiltIn "$^\|$?\|$_\|$\$"
+syn match ps1BuiltIn "$\%(args\|error\|foreach\|home\|input\)\>"
+syn match ps1BuiltIn "$\%(match\(es\)\?\|myinvocation\|host\|lastexitcode\)\>"
+syn match ps1BuiltIn "$\%(ofs\|shellid\|stacktrace\)\>"
 
 " Folding blocks
 syn region ps1Block start=/{/ end=/}/ transparent fold
@@ -122,6 +129,9 @@ if version >= 508 || !exists("did_ps1_syn_inits")
   HiLink ps1Variable Identifier
   HiLink ps1ScopedVariable Identifier
   HiLink ps1VariableName Identifier
+  HiLink ps1Boolean Boolean
+  HiLink ps1Constant Constant
+  HiLink ps1BuiltIn StorageClass
   HiLink ps1Type Type
   HiLink ps1Scope Type
   HiLink ps1StandaloneType Type


### PR DESCRIPTION
This patch adds support for:
- Special colors for Boolean and other constants
- Coloring for documentation/help comments (i.e. .Synopsis, etc.)
- Coloring for escape sequences in double quoted strings
- Coloring for replacement expressions in interpolated strings
