### PR TITLE
Use modeline to always set ft=help for docs.

### DIFF
--- a/doc/ps1.txt
+++ b/doc/ps1.txt
@@ -34,3 +34,5 @@ Digital signatures in scripts will also be folded unless you use: >
 Note: syntax folding might slow down syntax highlighting significantly,
 especially for large files.
 
+------------------------------------------------------------------------------
+ vim:ft=help:


### PR DESCRIPTION
Here is the modeline change you agreed to so that doc/ps1.txt is always displayed as a help file.
