### PR TITLE
Correct here-string syntax

### DIFF
--- a/syntax/ps1.vim
+++ b/syntax/ps1.vim
@@ -85,8 +85,8 @@ syn region ps1String start=/"/ skip=/`"/ end=/"/ contains=@ps1StringSpecial
 syn region ps1String start=/'/ skip=/''/ end=/'/
 
 " Here-Strings
-syn region ps1String start=/@"$/ end=/^"@$/ contains=@ps1StringSpecial
-syn region ps1String start=/@'$/ end=/^'@$/
+syn region ps1String start=/@"$/ end=/^"@/ contains=@ps1StringSpecial
+syn region ps1String start=/@'$/ end=/^'@/
 
 " Interpolation
 syn match ps1Escape /`./ contained


### PR DESCRIPTION
Here-strings do allow for commands after the closing token. Confirmed with PS team, as well as in their own syntax highlighting within the ISE.
