### PR TITLE
Corrected a syntax error occurring on Fedora 19 with vim 7.4.179

### DIFF
--- a/ftdetect/ps1.vim
+++ b/ftdetect/ps1.vim
@@ -4,7 +4,7 @@
 " Version:            2.10
 " Project Repository: https://github.com/PProvost/vim-ps1
 " Vim Script Page:    http://www.vim.org/scripts/script.php?script_id=1327
-
+"
 au BufNewFile,BufRead   *.ps1   set ft=ps1
 au BufNewFile,BufRead   *.psd1  set ft=ps1
 au BufNewFile,BufRead   *.psm1  set ft=ps1


### PR DESCRIPTION
Corrected a syntax error occurring on Fedora 19 with vim 7.4.179. Vim saw the carriage return character ^M and would throw a syntax error when opening a file. I have placed a commented line in the carriage return's place to address this. The error was "E492: Not an editor command: ^M".

Let me know what you think!

Thanks,
Persistent