### PR TITLE
Added spell checking for strings.

### DIFF
--- a/syntax/ps1.vim
+++ b/syntax/ps1.vim
@@ -81,18 +81,18 @@ syn keyword ps1Operator f contained
 
 " Regular Strings
 " These aren't precisely correct and could use some work
-syn region ps1String start=/"/ skip=/`"/ end=/"/ contains=@ps1StringSpecial,@spell
+syn region ps1String start=/"/ skip=/`"/ end=/"/ contains=@ps1StringSpecial,@Spell
 syn region ps1String start=/'/ skip=/''/ end=/'/
 
 " Here-Strings
-syn region ps1String start=/@"$/ end=/^"@/ contains=@ps1StringSpecial,@spell
+syn region ps1String start=/@"$/ end=/^"@/ contains=@ps1StringSpecial,@Spell
 syn region ps1String start=/@'$/ end=/^'@/
 
 " Interpolation
 syn match ps1Escape /`./ contained
 syn region ps1Interpolation matchgroup=ps1InterpolationDelimiter start="$(" end=")" contained contains=ALLBUT,@ps1NotTop
 syn region ps1NestedParentheses start="(" skip="\\\\\|\\)" matchgroup=ps1Interpolation end=")" transparent contained
-syn cluster ps1StringSpecial contains=ps1Escape,ps1Interpolation,ps1Variable,ps1Boolean,ps1Constant,ps1BuiltIn,@spell
+syn cluster ps1StringSpecial contains=ps1Escape,ps1Interpolation,ps1Variable,ps1Boolean,ps1Constant,ps1BuiltIn,@Spell
 
 " Numbers
 syn match   ps1Number		"\<\(0[xX]\x\+\|\d\+\)\([KMGTP][B]\)\=\>"

--- a/syntax/ps1.vim
+++ b/syntax/ps1.vim
@@ -81,18 +81,18 @@ syn keyword ps1Operator f contained
 
 " Regular Strings
 " These aren't precisely correct and could use some work
-syn region ps1String start=/"/ skip=/`"/ end=/"/ contains=@ps1StringSpecial 
+syn region ps1String start=/"/ skip=/`"/ end=/"/ contains=@ps1StringSpecial,@spell
 syn region ps1String start=/'/ skip=/''/ end=/'/
 
 " Here-Strings
-syn region ps1String start=/@"$/ end=/^"@/ contains=@ps1StringSpecial
+syn region ps1String start=/@"$/ end=/^"@/ contains=@ps1StringSpecial,@spell
 syn region ps1String start=/@'$/ end=/^'@/
 
 " Interpolation
 syn match ps1Escape /`./ contained
 syn region ps1Interpolation matchgroup=ps1InterpolationDelimiter start="$(" end=")" contained contains=ALLBUT,@ps1NotTop
 syn region ps1NestedParentheses start="(" skip="\\\\\|\\)" matchgroup=ps1Interpolation end=")" transparent contained
-syn cluster ps1StringSpecial contains=ps1Escape,ps1Interpolation,ps1Variable,ps1Boolean,ps1Constant,ps1BuiltIn
+syn cluster ps1StringSpecial contains=ps1Escape,ps1Interpolation,ps1Variable,ps1Boolean,ps1Constant,ps1BuiltIn,@spell
 
 " Numbers
 syn match   ps1Number		"\<\(0[xX]\x\+\|\d\+\)\([KMGTP][B]\)\=\>"


### PR DESCRIPTION
Spell checking was already added for comments (which isn't in the vimscripts version, unfortunately), but not provided for strings. I added that functionality here, it's a pretty straightforward patch.