### PR TITLE
Added psake (default) and pester 'compiler' options

### DIFF
--- a/compiler/pester.vim
+++ b/compiler/pester.vim
@@ -1,0 +1,8 @@
+" Pester in as "compiler"
+if exists("current_compiler")
+    finish
+endif
+
+let current_compiler = "pester"
+setlocal makeprg=powershell\ -command\ invoke-pester
+setlocal errorformat=%f:%l:%c:%m,%f:%m

--- a/compiler/psake.vim
+++ b/compiler/psake.vim
@@ -1,0 +1,8 @@
+" Psake in as "compiler"
+if exists("current_compiler")
+    finish
+endif
+
+let current_compiler = "psake"
+setlocal makeprg=powershell\ -command\ invoke-psake
+setlocal errorformat=%f:%l:%c:%m,%f:%m

--- a/ftplugin/ps1.vim
+++ b/ftplugin/ps1.vim
@@ -11,6 +11,8 @@ if exists("b:did_ftplugin") | finish | endif
 " Don't load another plug-in for this buffer
 let b:did_ftplugin = 1
 
+compiler psake
+
 setlocal tw=0
 setlocal commentstring=#%s
 setlocal formatoptions=tcqro


### PR DESCRIPTION
Opening this mostly to get eyes on it. I'd like to put in some logic to detect if a user has Psake or Pester installed (ideally need both since Psake is just "make" and Pester is the test framework).

I'm not sure if this is best done with an install.ps1 in the root of the repo that does this check or if there is a way to simply bomb out if ```powershell -Command Get-Command Invoke-Pester``` returns an error.

Currently I'm using this quite happily with tpope/vim-dispatch and it's pretty awesome.