### PR TITLE
Fix indent script

### DIFF
--- a/indent/ps1.vim
+++ b/indent/ps1.vim
@@ -1,9 +1,18 @@
 " Vim indent file
-" Language:           Windows PowerShell
-" Maintainer:         Peter Provost <peter@provost.org>
-" Version:            2.10
-" Project Repository: https://github.com/PProvost/vim-ps1
-" Vim Script Page:    http://www.vim.org/scripts/script.php?script_id=1327"
+" Language:		PowerShell
+" Maintainer:	Lior Elia - http://blogs.msdn.com/lior
+" Version:		2.0
+" Last Change:	2009 Oct 18
+" Changelist:
+" 	Ver		Date		By			Fixed indentation of...
+" 	-----	----------	--------	-----------------------------------------
+"	1.0		2009-10-04	LiorE		Comment rows
+" 	2.0		2009-10-18	LiorE		Lines after (.*), comments after '{' or
+"					 				'}' and many many other things. I've made
+"					 				this a major version change because there
+"					 				are many changes in the behavior.
+
+" Dedicated to my loving and supporting family: Anat, Amit and Ofir.
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -11,10 +20,77 @@ if exists("b:did_indent")
 endif
 let b:did_indent = 1
 
-" smartindent is good enough for powershell
-setlocal smartindent
-" disable the indent removal for # marks
-inoremap # X#
+setlocal cindent cinoptions& cinoptions+=+0
 
-let b:undo_indent = "setl si<"
+" Set the function to do the work.
+setlocal indentexpr=GetPsIndent()
+
+let b:undo_indent = "set cin< cino< indentkeys< indentexpr<"
+
+" Only define the function once.
+if exists("*GetPsIndent")
+	finish
+endif
+
+function! Log(text)
+		" Enable the line below for debugging
+		" call confirm(a:text)
+endfunction
+
+function! SkipPsComments(startline)
+	let lnum = a:startline
+	while lnum > 1
+		let lnum = prevnonblank(lnum)
+		if getline(lnum) =~ '^\s*#'
+			let lnum = lnum - 1
+		else
+			break
+		endif
+	endwhile
+	return lnum
+endfunction
+
+function GetPsIndent()
+
+	" PowerShell is almost like C; use the built-in C indenting and then correct the comment/precompiler duality.
+	let theIndent = cindent(v:lnum)
+	let prevLine = SkipPsComments(v:lnum-1)
+if (prevLine > 0)
+	let prevLineIndent = indent(prevLine)
+else
+	let prevLineIndent = 0
+endif
+
+	call Log("prevline " . prevLine . " - Indent is " . prevLineIndent)
+	" if prev line ends with paranthesis (...) it messes the indentation
+	if getline(prevLine) =~ '(.*)$'
+		" set the indent to be the same of the prev non blank non comment line
+		let theIndent = prevLineIndent
+		if getline(v:lnum) =~ '^[^{]*}'
+			" remove one indentation level, clsoing a block
+			let theIndent -= &sw
+		endif
+	endif
+
+	" comment lines are mishandled as precompiler directives ('#') so fix that.
+
+	call Log("before comment - Indent is " . theIndent)
+	" if current line is a comment...
+	if getline(v:lnum) =~ '^\s*#'
+		let theIndent = prevLineIndent
+		" if prev line opened a block -
+		if getline(prevLine) =~ '{$'
+			" indent once more, because we're in a beginning of a block
+			let theIndent += &sw
+		elseif getline(prevLine) =~ '([^)]*$'
+			" indent twice more, because we're in a beginning of a parameters
+			" block which gets indented twice by cindent, for some obscure
+			" reason...
+			let theIndent += &sw
+			let theIndent += &sw
+		endif
+	endif
+	call Log("After - Indent is " . theIndent)
+	return theIndent
+endfunction
 

--- a/indent/ps1.vim
+++ b/indent/ps1.vim
@@ -8,11 +8,11 @@
 " Changelist:
 " 	Ver		Date		By			Fixed indentation of...
 " 	-----	----------	--------	-----------------------------------------
-"	1.0		2009-10-04	LiorE		Comment rows
-" 	2.0		2009-10-18	LiorE		Lines after (.*), comments after '{' or
-"					 				'}' and many many other things. I've made
-"					 				this a major version change because there
-"					 				are many changes in the behavior.
+"	1.0     2009-10-04	LiorE       Comment rows
+" 	2.0     2009-10-18	LiorE       Lines after (.*), comments after '{' or
+"					 		        '}' and many many other things. I've made
+"					 		        this a major version change because there
+"					 		        are many changes in the behavior.
 " 	2.0.1   2016-08-10	cranej      Remove debug code
 
 " Dedicated to my loving and supporting family: Anat, Amit and Ofir.

--- a/indent/ps1.vim
+++ b/indent/ps1.vim
@@ -1,8 +1,8 @@
 " Vim indent file
-" Language:		PowerShell
-" Maintainer:	Lior Elia - http://blogs.msdn.com/lior
-" Version:		2.0
-" Last Change:	2009 Oct 18
+" Language:		Windows PowerShell
+" Maintainer:	Crane Jin <crane@cranejin.com>
+" Version:		2.0.1
+" Last Change:	2016 Aug 10
 " Changelist:
 " 	Ver		Date		By			Fixed indentation of...
 " 	-----	----------	--------	-----------------------------------------
@@ -11,12 +11,13 @@
 "					 				'}' and many many other things. I've made
 "					 				this a major version change because there
 "					 				are many changes in the behavior.
+" 	2.0.1		2016-08-10	cranej      Remove debug code
 
 " Dedicated to my loving and supporting family: Anat, Amit and Ofir.
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
-	finish
+    finish
 endif
 let b:did_indent = 1
 
@@ -29,68 +30,58 @@ let b:undo_indent = "set cin< cino< indentkeys< indentexpr<"
 
 " Only define the function once.
 if exists("*GetPsIndent")
-	finish
+    finish
 endif
 
-function! Log(text)
-		" Enable the line below for debugging
-		" call confirm(a:text)
-endfunction
-
 function! SkipPsComments(startline)
-	let lnum = a:startline
-	while lnum > 1
-		let lnum = prevnonblank(lnum)
-		if getline(lnum) =~ '^\s*#'
-			let lnum = lnum - 1
-		else
-			break
-		endif
-	endwhile
-	return lnum
+    let lnum = a:startline
+    while lnum > 1
+        let lnum = prevnonblank(lnum)
+        if getline(lnum) =~ '^\s*#'
+            let lnum = lnum - 1
+        else
+            break
+        endif
+    endwhile
+    return lnum
 endfunction
 
 function GetPsIndent()
+    " PowerShell is almost like C; use the built-in C indenting and then correct the comment/precompiler duality.
+    let theIndent = cindent(v:lnum)
+    let prevLine = SkipPsComments(v:lnum-1)
+    if (prevLine > 0)
+        let prevLineIndent = indent(prevLine)
+    else
+        let prevLineIndent = 0
+    endif
 
-	" PowerShell is almost like C; use the built-in C indenting and then correct the comment/precompiler duality.
-	let theIndent = cindent(v:lnum)
-	let prevLine = SkipPsComments(v:lnum-1)
-if (prevLine > 0)
-	let prevLineIndent = indent(prevLine)
-else
-	let prevLineIndent = 0
-endif
+    " if prev line ends with paranthesis (...) it messes the indentation
+    if getline(prevLine) =~ '(.*)$'
+        " set the indent to be the same of the prev non blank non comment line
+        let theIndent = prevLineIndent
+        if getline(v:lnum) =~ '^[^{]*}'
+            " remove one indentation level, clsoing a block
+            let theIndent -= &sw
+        endif
+    endif
 
-	call Log("prevline " . prevLine . " - Indent is " . prevLineIndent)
-	" if prev line ends with paranthesis (...) it messes the indentation
-	if getline(prevLine) =~ '(.*)$'
-		" set the indent to be the same of the prev non blank non comment line
-		let theIndent = prevLineIndent
-		if getline(v:lnum) =~ '^[^{]*}'
-			" remove one indentation level, clsoing a block
-			let theIndent -= &sw
-		endif
-	endif
-
-	" comment lines are mishandled as precompiler directives ('#') so fix that.
-
-	call Log("before comment - Indent is " . theIndent)
-	" if current line is a comment...
-	if getline(v:lnum) =~ '^\s*#'
-		let theIndent = prevLineIndent
-		" if prev line opened a block -
-		if getline(prevLine) =~ '{$'
-			" indent once more, because we're in a beginning of a block
-			let theIndent += &sw
-		elseif getline(prevLine) =~ '([^)]*$'
-			" indent twice more, because we're in a beginning of a parameters
-			" block which gets indented twice by cindent, for some obscure
-			" reason...
-			let theIndent += &sw
-			let theIndent += &sw
-		endif
-	endif
-	call Log("After - Indent is " . theIndent)
-	return theIndent
+    " comment lines are mishandled as precompiler directives ('#') so fix that.
+    " if current line is a comment...
+    if getline(v:lnum) =~ '^\s*#'
+        let theIndent = prevLineIndent
+        " if prev line opened a block -
+        if getline(prevLine) =~ '{$'
+            " indent once more, because we're in a beginning of a block
+            let theIndent += &sw
+        elseif getline(prevLine) =~ '([^)]*$'
+            " indent twice more, because we're in a beginning of a parameters
+            " block which gets indented twice by cindent, for some obscure
+            " reason...
+            let theIndent += &sw
+            let theIndent += &sw
+        endif
+    endif
+    return theIndent
 endfunction
 

--- a/indent/ps1.vim
+++ b/indent/ps1.vim
@@ -1,19 +1,17 @@
 " Vim indent file
-" Language:		Windows PowerShell
+" Language:       Windows PowerShell
 " Maintainer:
 "   Lior Elia - http://blogs.msdn.com/lior
 "   Crane Jin <crane@cranejin.com>
-" Version:		2.0.1
-" Last Change:	2016 Aug 10
+" Version:        2.0.1
+" Last Change:    2016 Aug 10
 " Changelist:
-" 	Ver		Date		By			Fixed indentation of...
-" 	-----	----------	--------	-----------------------------------------
-"	1.0     2009-10-04	LiorE       Comment rows
-" 	2.0     2009-10-18	LiorE       Lines after (.*), comments after '{' or
-"					 		        '}' and many many other things. I've made
-"					 		        this a major version change because there
-"					 		        are many changes in the behavior.
-" 	2.0.1   2016-08-10	cranej      Remove debug code
+"    1.0     2009-10-04    LiorE       Comment rows
+"    2.0     2009-10-18    LiorE       Lines after (.*), comments after '{' or
+"                                      '}' and many many other things. I've made
+"                                      this a major version change because there
+"                                      are many changes in the behavior.
+"    2.0.1   2016-08-10    cranej      Remove debug code
 
 " Dedicated to my loving and supporting family: Anat, Amit and Ofir.
 

--- a/indent/ps1.vim
+++ b/indent/ps1.vim
@@ -1,6 +1,8 @@
 " Vim indent file
 " Language:		Windows PowerShell
-" Maintainer:	Crane Jin <crane@cranejin.com>
+" Maintainer:
+"   Lior Elia - http://blogs.msdn.com/lior
+"   Crane Jin <crane@cranejin.com>
 " Version:		2.0.1
 " Last Change:	2016 Aug 10
 " Changelist:
@@ -11,7 +13,7 @@
 "					 				'}' and many many other things. I've made
 "					 				this a major version change because there
 "					 				are many changes in the behavior.
-" 	2.0.1		2016-08-10	cranej      Remove debug code
+" 	2.0.1   2016-08-10	cranej      Remove debug code
 
 " Dedicated to my loving and supporting family: Anat, Amit and Ofir.
 


### PR DESCRIPTION
`smartindent` does not work correctly for even simple PowerShell script like the following:

After indentation:
```powershell
$variable1 = ""
$variable2 = [System.Collection.ArrayList]@()
    function Function1{
        param([string]$p1, [string]$p2)
            $p1 = $ps.Trim("\r\n")
            Write-Host "Test"
            exit
    }
```
Script <http://www.vim.org/scripts/script.php?script_id=2800> works greatly with even more complex scripts.  So I'd like to suggest to include it into the plugin. 

Thanks.