### PR TITLE
Fixed escaping of quotes to allow them to be passed to the shell

### DIFF
--- a/syntax/ps1.vim
+++ b/syntax/ps1.vim
@@ -93,7 +93,7 @@ syn region ps1String start=/@"$/ end=/^"@/ contains=@ps1StringSpecial,@Spell
 syn region ps1String start=/@'$/ end=/^'@/
 
 " Interpolation
-syn match ps1Escape /`./    " NOT contained - you can escape quotes to prevent quoting.
+syn match ps1Escape /`./
 syn region ps1Interpolation matchgroup=ps1InterpolationDelimiter start="$(" end=")" contained contains=ALLBUT,@ps1NotTop
 syn region ps1NestedParentheses start="(" skip="\\\\\|\\)" matchgroup=ps1Interpolation end=")" transparent contained
 syn cluster ps1StringSpecial contains=ps1Escape,ps1Interpolation,ps1Variable,ps1Boolean,ps1Constant,ps1BuiltIn,@Spell

--- a/syntax/ps1.vim
+++ b/syntax/ps1.vim
@@ -93,7 +93,7 @@ syn region ps1String start=/@"$/ end=/^"@/ contains=@ps1StringSpecial,@Spell
 syn region ps1String start=/@'$/ end=/^'@/
 
 " Interpolation
-syn match ps1Escape /`./ contained
+syn match ps1Escape /`./    " NOT contained - you can escape quotes to prevent quoting.
 syn region ps1Interpolation matchgroup=ps1InterpolationDelimiter start="$(" end=")" contained contains=ALLBUT,@ps1NotTop
 syn region ps1NestedParentheses start="(" skip="\\\\\|\\)" matchgroup=ps1Interpolation end=")" transparent contained
 syn cluster ps1StringSpecial contains=ps1Escape,ps1Interpolation,ps1Variable,ps1Boolean,ps1Constant,ps1BuiltIn,@Spell


### PR DESCRIPTION
The syntax highlighter wasn't working with `\`"` passed as a literal quote on the command line.

This was somewhat obscure but notably was used for a `mklink` script I had found where it had to pass literal quotes to an invocation of `cmd`.
```powershell
    cmd /c mklink `"$Link`" `"$Target`"
```

I haven't thoroughly tested this in all situations, but I am unaware of what pitfalls this may have.

Thanks!
\# Chris
