### PR TITLE
Add #region folding to ps1.vim

### DIFF
--- a/syntax/ps1.vim
+++ b/syntax/ps1.vim
@@ -8,6 +8,7 @@
 " The following settings are available for tuning syntax highlighting:
 "    let ps1_nofold_blocks = 1
 "    let ps1_nofold_sig = 1
+"    let ps1_nofold_region = 1
 
 " Compatible VIM syntax file start
 if version < 600
@@ -135,6 +136,10 @@ if !exists('g:ps1_nofold_blocks')
 	syn region ps1Block start=/{/ end=/}/ transparent fold
 endif
 
+if !exists('g:ps1_nofold_region')
+	syn region ps1Region start=/#region/ end=/#endregion/ transparent fold keepend extend
+endif
+
 if !exists('g:ps1_nofold_sig')
 	syn region ps1Signature start=/# SIG # Begin signature block/ end=/# SIG # End signature block/ transparent fold
 endif
@@ -150,6 +155,7 @@ if version >= 508 || !exists("did_ps1_syn_inits")
 
 	HiLink ps1Number Number
 	HiLink ps1Block Block
+	HiLink ps1Region Region
 	HiLink ps1Exception Exception
 	HiLink ps1Constant Constant
 	HiLink ps1String String
@@ -177,4 +183,3 @@ if version >= 508 || !exists("did_ps1_syn_inits")
 endif
 
 let b:current_syntax = "ps1"
-


### PR DESCRIPTION
I hope I didn't miss anything in the existing folding definitions or in past discussions. Here is a small change in respect to region folding for PS. 

PowerShell allows using #region <comment> and #endregion markers to define regions within PowerShell scripts. To use the folding within VIM a new folding region was defined. The corresponding variable "ps1_nofold_region" is also used according to the existing block fold "g:ps1_nofold_blocks". It supports nested regions.

See e.g. https://blogs.technet.microsoft.com/heyscriptingguy/2014/11/12/use-regions-for-powershell-comments/ or https://blogs.technet.microsoft.com/heyscriptingguy/2015/11/12/use-regions-in-powershell-ise-2/.