### PR TITLE
Add bomb option.

### DIFF
--- a/ftplugin/ps1.vim
+++ b/ftplugin/ps1.vim
@@ -17,6 +17,8 @@ setlocal formatoptions=tcqro
 " Enable autocompletion of hyphenated PowerShell commands,
 " e.g. Get-Content or Get-ADUser
 setlocal iskeyword+=-
+" MS applications (including PowerShell) require a Byte Order Mark (BOM) for UTF-8.
+setlocal bomb
 
 " Change the browse dialog on Win32 to show mainly PowerShell-related files
 if has("gui_win32")

--- a/ftplugin/ps1xml.vim
+++ b/ftplugin/ps1xml.vim
@@ -14,9 +14,6 @@ let b:did_ftplugin = 1
 setlocal tw=0
 setlocal commentstring=#%s
 setlocal formatoptions=tcqro
-" Enable autocompletion of hyphenated PowerShell commands,
-" e.g. Get-Content or Get-ADUser
-setlocal iskeyword+=-
 " MS applications (including PowerShell) require a Byte Order Mark (BOM) for UTF-8.
 setlocal bomb
 

--- a/ftplugin/ps1xml.vim
+++ b/ftplugin/ps1xml.vim
@@ -14,6 +14,11 @@ let b:did_ftplugin = 1
 setlocal tw=0
 setlocal commentstring=#%s
 setlocal formatoptions=tcqro
+" Enable autocompletion of hyphenated PowerShell commands,
+" e.g. Get-Content or Get-ADUser
+setlocal iskeyword+=-
+" MS applications (including PowerShell) require a Byte Order Mark (BOM) for UTF-8.
+setlocal bomb
 
 " Change the browse dialog on Win32 to show mainly PowerShell-related files
 if has("gui_win32")


### PR DESCRIPTION
Windows PowerShell requires a BOM for scripts encoded with UTF-8.

I came across this problem when a function that I had declared in my user profile (`$PROFILE`) started printing `â€˜` instead of `‘` and `â€™` instead of  `’`.  See also <https://stackoverflow.com/q/14482253/1640661>

I had originally tested for the (file) encoding like so:

    if &encoding == 'utf-8'
      setlocal bomb
    endif

However, after thinking about it, I concluded this wasn’t necessary since setting the `bomb` option won’t have any effect – unless `fileencoding` is set to

> "utf-8", "ucs-2", "ucs-4" or one of the little/big endian variants.

---

By the way, I don’t know what the purpose of `ftplugin/ps1xml.vim` is but I updated that file as well as `ftplugin/ps1.vim `
