### PR TITLE
Set file format to 'dos'

### DIFF
--- a/ftplugin/ps1.vim
+++ b/ftplugin/ps1.vim
@@ -14,6 +14,7 @@ let b:did_ftplugin = 1
 setlocal tw=0
 setlocal commentstring=#%s
 setlocal formatoptions=tcqro
+setlocal fileformat=dos
 " Enable autocompletion of hyphenated PowerShell commands,
 " e.g. Get-Content or Get-ADUser
 setlocal iskeyword+=-

--- a/ftplugin/ps1xml.vim
+++ b/ftplugin/ps1xml.vim
@@ -14,6 +14,7 @@ let b:did_ftplugin = 1
 setlocal tw=0
 setlocal commentstring=#%s
 setlocal formatoptions=tcqro
+setlocal fileformat=dos
 " MS applications (including PowerShell) require a Byte Order Mark (BOM) for UTF-8.
 setlocal bomb
 


### PR DESCRIPTION
Currently if create a PowerShell script on Linux and copy it to Windows, the line breaks get messed.