### PR TITLE
Define buffer-local keymap instead of global one

### DIFF
--- a/indent/ps1.vim
+++ b/indent/ps1.vim
@@ -14,7 +14,7 @@ let b:did_indent = 1
 " smartindent is good enough for powershell
 setlocal smartindent
 " disable the indent removal for # marks
-inoremap # X#
+inoremap <buffer> # X#
 
 let b:undo_indent = "setl si<"
 


### PR DESCRIPTION
It may be safer in composite filetype projects.