### PR TITLE
Update to ps1.vim

### DIFF
--- a/syntax/ps1.vim
+++ b/syntax/ps1.vim
@@ -104,12 +104,12 @@ syn match ps1Operator /\(^\|\s\)\@<=\. \@=/
 
 " Regular Strings
 " These aren't precisely correct and could use some work
-syn region ps1String start=/"/ skip=/`"/ end=/"/ contains=@ps1StringSpecial,@Spell
-syn region ps1String start=/'/ skip=/''/ end=/'/
+syn region ps1String start=/"/ skip=/[`]"/ end=/"/ contains=@ps1StringSpecial 
+syn region ps1String start=/'/ skip=/[`]'/ end=/'/
 
 " Here-Strings
-syn region ps1String start=/@"$/ end=/^"@/ contains=@ps1StringSpecial,@Spell
-syn region ps1String start=/@'$/ end=/^'@/
+syn region ps1String start=/[@]["]/ end=/^["][@]/ contains=@ps1StringSpecial
+syn region ps1String start=/[@][']/ end=/^['][@]/
 
 " Interpolation
 syn match ps1Escape /`./

--- a/syntax/ps1.vim
+++ b/syntax/ps1.vim
@@ -104,11 +104,11 @@ syn match ps1Operator /\(^\|\s\)\@<=\. \@=/
 
 " Regular Strings
 " These aren't precisely correct and could use some work
-syn region ps1String start=/"/ skip=/[`]"/ end=/"/ contains=@ps1StringSpecial 
+syn region ps1String start=/"/ skip=/[`]"/ end=/"/ contains=@ps1StringSpecial,@Spell 
 syn region ps1String start=/'/ skip=/[`]'/ end=/'/
 
 " Here-Strings
-syn region ps1String start=/[@]["]/ end=/^["][@]/ contains=@ps1StringSpecial
+syn region ps1String start=/[@]["]/ end=/^["][@]/ contains=@ps1StringSpecial,@Spell
 syn region ps1String start=/[@][']/ end=/^['][@]/
 
 " Interpolation


### PR DESCRIPTION
Modify the regex match on lines 107 - 112 to properly identify multi-line strings, and escapes in regular strings.