### PR TITLE
Make docstring Parameters less visible

### DIFF
--- a/syntax/ps1.vim
+++ b/syntax/ps1.vim
@@ -173,7 +173,7 @@ if version >= 508 || !exists("did_ps1_syn_inits")
 	HiLink ps1Comment Comment
 	HiLink ps1CommentTodo Todo
 	HiLink ps1CommentDoc Tag
-	HiLink ps1CDocParam Function
+	HiLink ps1CDocParam Identifier
 	HiLink ps1Operator Operator
 	HiLink ps1Repeat Repeat
 	HiLink ps1RepeatAndCmdlet Repeat

--- a/syntax/ps1.vim
+++ b/syntax/ps1.vim
@@ -173,7 +173,7 @@ if version >= 508 || !exists("did_ps1_syn_inits")
 	HiLink ps1Comment Comment
 	HiLink ps1CommentTodo Todo
 	HiLink ps1CommentDoc Tag
-	HiLink ps1CDocParam Todo
+	HiLink ps1CDocParam Function
 	HiLink ps1Operator Operator
 	HiLink ps1Repeat Repeat
 	HiLink ps1RepeatAndCmdlet Repeat


### PR DESCRIPTION
Docstrings after the keyword `.PARAMETER` got the highlight for `Todo`, which looks quite noisy, at least in my color scheme. Might it be less intrusive to simply give them the same color they have in-code, namly `Function`? (IMHO `Operator` looks fine as well.)