### PR TITLE
Add compiler for running powershell scripts

### DIFF
--- a/compiler/powershell.vim
+++ b/compiler/powershell.vim
@@ -1,0 +1,76 @@
+" Compiler:	powershell
+" Run ps1 scripts in powershell and process their output. Quickly jump through
+" stack traces and see script output in the quickfix.
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "powershell"
+
+if exists(":CompilerSet") != 2		" older Vim always used :setlocal
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:cpo_save = &cpo
+set cpo-=C
+
+if !exists("g:ps1_makeprg_cmd")
+  if !has('win32') || executable('pwsh')
+    " pwsh is the future
+    let g:ps1_makeprg_cmd = 'pwsh'
+  else
+    " powershell is Windows-only
+    let g:ps1_makeprg_cmd = 'powershell'
+  endif
+endif
+
+" Show CategoryInfo, FullyQualifiedErrorId, etc?
+let g:ps1_efm_show_error_categories = get(g:, 'ps1_efm_show_error_categories', 0)
+
+" Use absolute path because powershell requires explicit relative paths
+" (./file.ps1 is okay, but # expands to file.ps1)
+let &l:makeprg = g:ps1_makeprg_cmd .' %:p'
+
+" Parse file, line, char from callstacks:
+"     Write-Ouput : The term 'Write-Ouput' is not recognized as the name of a
+"     cmdlet, function, script file, or operable program. Check the spelling
+"     of the name, or if a path was included, verify that the path is correct
+"     and try again.
+"     At C:\script.ps1:11 char:5
+"     +     Write-Ouput $content
+"     +     ~~~~~~~~~~~
+"         + CategoryInfo          : ObjectNotFound: (Write-Ouput:String) [], CommandNotFoundException
+"         + FullyQualifiedErrorId : CommandNotFoundException
+
+" Showing error in context with underlining.
+CompilerSet errorformat=%+G+%m
+" Error summary.
+CompilerSet errorformat+=%E%*\\S\ :\ %m
+" Error location.
+CompilerSet errorformat+=%CAt\ %f:%l\ char:%c
+" Errors that span multiple lines (may be wrapped to width of terminal).
+CompilerSet errorformat+=%C%m
+" Ignore blank/whitespace-only lines.
+CompilerSet errorformat+=%Z\\s%#
+
+if g:ps1_efm_show_error_categories
+  CompilerSet errorformat^=%+G\ \ \ \ +\ %.%#\\s%#:\ %m
+else
+  CompilerSet errorformat^=%-G\ \ \ \ +\ %.%#\\s%#:\ %m
+endif
+
+
+" Parse file, line, char from of parse errors:
+"     At C:\script.ps1:22 char:16
+"     + Stop-Process -Name "invalidprocess
+"     +                    ~~~~~~~~~~~~~~~
+"     The string is missing the terminator: ".
+"         + CategoryInfo          : ParserError: (:) [], ParseException
+"         + FullyQualifiedErrorId : TerminatorExpectedAtEndOfString
+CompilerSet errorformat+=At\ %f:%l\ char:%c
+
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim:set sw=2 sts=2:

--- a/doc/ps1.txt
+++ b/doc/ps1.txt
@@ -34,5 +34,21 @@ Digital signatures in scripts will also be folded unless you use: >
 Note: syntax folding might slow down syntax highlighting significantly,
 especially for large files.
 
+
+COMPILER                                                        *ps1-compiler*
+
+The powershell |compiler| script configures |:make| to execute the script in
+PowerShell.
+
+It tries to pick a smart default PowerShell command: `pwsh` if available and
+`powershell` otherwise, but you can customize the command: >
+
+    :let g:ps1_makeprg_cmd = '/path/to/pwsh'
+<
+To configure whether to show the exception type information: >
+
+    :let g:ps1_efm_show_error_categories = 1
+<
+
 ------------------------------------------------------------------------------
  vim:ft=help:


### PR DESCRIPTION
Add a compiler script to directly invoke powershell scripts and process
their output. Quickly jump through stack traces and see script output in
the quickfix.

Named this 'powershell' instead of ps1 since compilers tend to match
their command name.

In my quickfix, errors look like:

```
let g:ps1_efm_show_error_categories = 0

C:/script.ps1|11 col 5 error| The term 'Write-Ouput' is not recognized
as the name of a cmdlet, function, script file, or operable program.
Check the spelling of the  name, or if a path was included, verify that
the path is correct and try again.
|| +     Write-Ouput $content
|| +     ~~~~~~~~~~~

let g:ps1_efm_show_error_categories = 1

C:/script.ps1|11 col 5 error| The term 'Write-Ouput' is not recognized
as the name of a cmdlet, function, script file, or operable program.
Check the spelling of the  name, or if a path was included, verify that
the path is correct and try again.
|| +     Write-Ouput $content
|| +     ~~~~~~~~~~~
||     + CategoryInfo          : ObjectNotFound: (Write-Ouput:String) [], CommandNotFoundException
||     + FullyQualifiedErrorId : CommandNotFoundException
```