### PR TITLE
make compiler work under WSL and shellescape file path

### DIFF
--- a/compiler/powershell.vim
+++ b/compiler/powershell.vim
@@ -15,13 +15,19 @@ let s:cpo_save = &cpo
 set cpo-=C
 
 if !exists("g:ps1_makeprg_cmd")
-  if !has('win32') || executable('pwsh')
+  if executable('pwsh')
     " pwsh is the future
     let g:ps1_makeprg_cmd = 'pwsh'
+  elseif executable('pwsh.exe')
+    let g:ps1_makeprg_cmd = 'pwsh.exe'
+  elseif executable('powershell.exe')
+    let g:ps1_makeprg_cmd = 'powershell.exe'
   else
-    " powershell is Windows-only
-    let g:ps1_makeprg_cmd = 'powershell'
-  endif
+    let g:ps1_makeprg_cmd = ''
+endif
+
+if !executable(g:ps1_makeprg_cmd)
+  echoerr "To use the powershell compiler, please set g:ps1_makeprg_cmd to the powershell executable!"
 endif
 
 " Show CategoryInfo, FullyQualifiedErrorId, etc?
@@ -29,7 +35,7 @@ let g:ps1_efm_show_error_categories = get(g:, 'ps1_efm_show_error_categories', 0
 
 " Use absolute path because powershell requires explicit relative paths
 " (./file.ps1 is okay, but # expands to file.ps1)
-let &l:makeprg = g:ps1_makeprg_cmd .' %:p'
+let &l:makeprg = g:ps1_makeprg_cmd .' %:p:S'
 
 " Parse file, line, char from callstacks:
 "     Write-Ouput : The term 'Write-Ouput' is not recognized as the name of a


### PR DESCRIPTION
WSH needs `.exe` appended to Windows executables and `:S` ensures the file path is escaped for shell processing