### PR TITLE
Fix compiler detection

### DIFF
--- a/compiler/powershell.vim
+++ b/compiler/powershell.vim
@@ -24,6 +24,7 @@ if !exists("g:ps1_makeprg_cmd")
     let g:ps1_makeprg_cmd = 'powershell.exe'
   else
     let g:ps1_makeprg_cmd = ''
+  endif
 endif
 
 if !executable(g:ps1_makeprg_cmd)


### PR DESCRIPTION
Upon enabling the compiler with `:compiler powershell` the following error occurs.

```
Error detected while processing ~/.vim/bundle/vim-ps1/compiler/powershell.vim:                                                                                                                          
line   83:                                                                                                                                                                                                        
E171: Missing :endif
```

The plugin does not fail to detect the PowerShell binary however, so this is just to fix the syntax to prevent the error.