### PR TITLE
Allow more liberal curly-brace variable names

### DIFF
--- a/syntax/ps1.vim
+++ b/syntax/ps1.vim
@@ -82,7 +82,7 @@ syn match ps1Type /\[[a-z_][a-z0-9_.,\[\]]\+\]/
 " Variable references
 syn match ps1ScopeModifier /\(global:\|local:\|private:\|script:\)/ contained
 syn match ps1Variable /\$\w\+\(:\w\+\)\?/ contains=ps1ScopeModifier
-syn match ps1Variable /\${\w\+\(:\w\+\)\?}/ contains=ps1ScopeModifier
+syn match ps1Variable /\${\w\+\(:[[:alnum:]_()]\+\)\?}/ contains=ps1ScopeModifier
 
 " Operators
 syn keyword ps1Operator -eq -ne -ge -gt -lt -le -like -notlike -match -notmatch -replace -split -contains -notcontains

--- a/syntax/ps1.vim
+++ b/syntax/ps1.vim
@@ -82,7 +82,7 @@ syn match ps1Type /\[[a-z_][a-z0-9_.,\[\]]\+\]/
 " Variable references
 syn match ps1ScopeModifier /\(global:\|local:\|private:\|script:\)/ contained
 syn match ps1Variable /\$\w\+\(:\w\+\)\?/ contains=ps1ScopeModifier
-syn match ps1Variable /\${\w\+\(:[[:alnum:]_()]\+\)\?}/ contains=ps1ScopeModifier
+syn match ps1Variable /\${\w\+\(:\?[[:alnum:]_()]\+\)\?}/ contains=ps1ScopeModifier
 
 " Operators
 syn keyword ps1Operator -eq -ne -ge -gt -lt -le -like -notlike -match -notmatch -replace -split -contains -notcontains


### PR DESCRIPTION
In the documentation at [1] it is stated that variable names enclosed in curly braces may contain any Unicode character except closing curly brace (}) and backtick (`).

A real-world example used on Windows 10 is ${env:ProgramFiles(x86)} to refer to C:\Program Files (x86).

[1] https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_variables?view=powershell-7#variable-names-that-include-special-characters