### PR TITLE
Improve string literal syntax

### DIFF
--- a/syntax/ps1.vim
+++ b/syntax/ps1.vim
@@ -112,12 +112,12 @@ syn match ps1Operator /\(^\|\s\)\@<=\. \@=/
 
 " Regular Strings
 " These aren't precisely correct and could use some work
-syn region ps1String start=/"/ skip=/`"/ end=/"/ contains=@ps1StringSpecial,@Spell
-syn region ps1String start=/'/ skip=/''/ end=/'/
+syn region ps1String start=/["\u201c-\u201e]/ skip=/`["\u201c-\u201e]/ end=/["\u201c-\u201e]/ contains=@ps1StringSpecial,@Spell
+syn region ps1String start=/['\u2018-\u201b]/ end=/['\u2018-\u201b]/
 
 " Here-Strings
-syn region ps1String start=/@"$/ end=/^"@/ contains=@ps1StringSpecial,@Spell
-syn region ps1String start=/@'$/ end=/^'@/
+syn region ps1String start=/@["\u201c-\u201e]$/ end=/^["\u201c-\u201e]@/ contains=@ps1StringSpecial,@Spell
+syn region ps1String start=/@['\u2018-\u201b]$/ end=/^['\u2018-\u201b]@/
 
 " Interpolation
 syn match ps1Escape /`./


### PR DESCRIPTION
Delimiters of string literals are somewhat surprising in PowerShell: for example `“a"„b”` is a single string equivalent to `'a„b'` while `"a„b"` is a syntax error. Currently these are highlighted incorrectly and it can be quite confusing. PowerShell syntax defines double quote are any of " “ ” „ and single quote as any of ' ‘ ’ ‚ ‛ so I would like to adjust start and end delimiters accordingly. Additionally the skip parameter for doubled delimiter (`skip=/''/`) is superfluous as far as syntax highlighting goes.