### PR TITLE
Prevent negative numbers from being highlighted as labels

### DIFF
--- a/syntax/ps1.vim
+++ b/syntax/ps1.vim
@@ -140,7 +140,7 @@ syn match ps1BuiltIn "$\%(match\(es\)\?\|myinvocation\|host\|lastexitcode\)\>"
 syn match ps1BuiltIn "$\%(ofs\|shellid\|stacktrace\)\>"
 
 " Named Switch
-syn match ps1Label /\s-\w\+/
+syn match ps1Label /\s-\h\w*/
 
 " Folding blocks
 if !exists('g:ps1_nofold_blocks')


### PR DESCRIPTION
Previously, negative numbers preceded by white-space where highlighted as `ps1Label` instead of `ps1Number`. (Strictly speaking, the minus sign of a negative number is always highlighted as `ps1Operator` and only the remainder is highlighted as `ps1Number`, but this is besides the point of this pull request.)

This pull request corrects this by requiring that the named parameter in a `ps1Label` must start with a head-of-word digit. (See `:help /\h` for information on the corresponding character class.)

While I have not found any proper grammar for Windows PowerShell or PowerShell Core, this seems to be consistent with the way PowerShell Core parses named parameters:

For example, evaluating
```ps1
function Test {
  param(
    $1a = 0
  )
  $1a
}

Test -1a 1
```
using <https://tio.run/#powershell-core> outputs `-1a` implying that PowerShell is parsing `-1a` not as a named parameter but as the value for a positional parameter instead. (The same would happen if one would omit the trailing `a`s, by the way.)

Compare this with the output of
```ps1
function Test {
  param(
    $a1 = 0
  )
  $a1
}

Test -a1 1
```
where `-a1` is indeed parsed as a named parameter and `1` is output instead.